### PR TITLE
Validatorの翻訳を送ります。

### DIFF
--- a/book/validator/constraints.rst
+++ b/book/validator/constraints.rst
@@ -1,0 +1,295 @@
+制約
+===========
+
+.. The Validator is designed to validate objects against *constraints*.
+   In real life, a constraint could be: "The cake must not be burned". In
+   Symfony2, constraints are similar: They are assertions that a condition is 
+   true.
+
+Validator は *制約* に対してオブジェクトが有効であるか確認する (バリデートする) ためにデザインされたものです。実生活では、制約とは「ケーキは焦がしてはならない」といったことです。 Symfony2 における制約は、条件が正であるアサーションに似ています。
+
+サポートされる制約
+---------------------
+
+.. The following constraints are natively available in Symfony2:
+
+以下の制約は Symfony2 で始めから使用可能なものです。
+
+.. toctree::
+    :hidden:
+
+    constraints/index
+
+* :doc:`AssertFalse <constraints/AssertFalse>`
+* :doc:`AssertTrue <constraints/AssertTrue>`
+* :doc:`AssertType <constraints/AssertType>`
+* :doc:`Choice <constraints/Choice>`
+* :doc:`Collection <constraints/Collection>`
+* :doc:`Date <constraints/Date>`
+* :doc:`DateTime <constraints/DateTime>`
+* :doc:`Email <constraints/Email>`
+* :doc:`File <constraints/File>`
+* :doc:`Max <constraints/Max>`
+* :doc:`MaxLength <constraints/MaxLength>`
+* :doc:`Min <constraints/Min>`
+* :doc:`MinLength <constraints/MinLength>`
+* :doc:`NotBlank <constraints/NotBlank>`
+* :doc:`NotNull <constraints/NotNull>`
+* :doc:`Regex <constraints/Regex>`
+* :doc:`Time <constraints/Time>`
+* :doc:`Url <constraints/Url>`
+* :doc:`Valid <constraints/Valid>`
+
+制約のターゲット
+------------------
+
+.. Constraints can be put on properties of a class, on public getters and on the
+   class itself. The benefit of class constraints is that they can validate
+   the whole state of an object at once, with all of its properties and methods.
+
+制約は、クラスのプロパティーやパブリックなゲッター、あるいはクラス自体に適用されるものです。クラスの制約の利点は、全てのプロパティやメソッドと一緒に、オブジェクトの状態の全体をいっぺんでバリデーションできることです。
+
+プロパティー
+~~~~~~~~~~
+
+.. Validating class properties is the most basic validation technique. Symfony2
+   allows you to validate private, protected or public properties. The next
+   listing shows how to configure the properties ``$firstName`` and ``$lastName``
+   of a class ``Author`` to have at least 3 characters.
+
+クラスのプロパティーのバリデーションは、最も標準的なバリデーションテクニックです。 Symfony2 は private 、 protected 、public の各プロパティーのバリデーションが可能です。次の例では、 ``Author`` クラスの ``$firstName`` と ``$lastName`` というプロパティーが最低3文字保持するように設定する方法を表します。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Author:
+            properties:
+                firstName:
+                    - NotBlank: ~
+                    - MinLength: 3
+                lastName:
+                    - NotBlank: ~
+                    - MinLength: 3
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <property name="firstName">
+                <constraint name="NotBlank" />
+                <constraint name="MinLength">3</constraint>
+            </property>
+            <property name="lastName">
+                <constraint name="NotBlank" />
+                <constraint name="MinLength">3</constraint>
+            </property>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /**
+             * @validation:NotBlank()
+             * @validation:MinLength(3)
+             */
+            private $firstName;
+
+            /**
+             * @validation:NotBlank()
+             * @validation:MinLength(3)
+             */
+            private $lastName;
+        }
+
+    .. code-block:: php
+
+        // Sensio/HelloBundle/Author.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints\NotBlank;
+        use Symfony\Component\Validator\Constraints\MinLength;
+        
+        class Author
+        {
+            private $firstName;
+
+            private $lastName;
+
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('firstName', new NotBlank());
+                $metadata->addPropertyConstraint('firstName', new MinLength(3));
+                $metadata->addPropertyConstraint('lastName', new NotBlank());
+                $metadata->addPropertyConstraint('lastName', new MinLength(3));
+            }
+        }
+
+ゲッター
+~~~~~~~
+
+.. The next validation technique is to constrain the return value of a method.
+   Symfony2 allows you to constrain any public method whose name starts with
+   "get" or "is". In this guide, this is commonly referred to as "getter".
+
+次のバリデーションテクニックは、メソッドの返り値に対する制約です。 Symfony2 は、"get" または "is" で始まる名前を持つあらゆるパブリックなメソッドに制約をかけられます。このガイドでは一般に "getter" と呼びます。
+
+.. The benefit of this technique is that it allows you to validate your object
+   dynamically. Depending on the state of your object, the method may return
+   different values which are then validated.
+
+このテクニックの利点は、オブジェクトを動的にバリデーションできることです。オブジェクトの状態によって、メソッドはバリデーションされた異なる値を返します。
+
+.. The next listing shows you how to use the :doc:`AssertTrue
+   <constraints/AssertTrue>` constraint to validate whether a dynamically
+   generated token is correct:
+
+以下の例では、動的に生成されたトークンが正しいかどうかをバリデーションする :doc:`AssertTrue <constraints/AssertTrue>` の使い方を示します。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Author:
+            getters:
+                tokenValid:
+                    - AssertTrue: { message: "The token is invalid" }
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <getter property="tokenValid">
+                <constraint name="AssertTrue">
+                    <option name="message">The token is invalid</option>
+                </constraint>
+            </getter>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /**
+             * @validation:AssertTrue(message = "The token is invalid")
+             */
+            public function isTokenValid()
+            {
+                // return true or false
+            }
+        }
+
+    .. code-block:: php
+
+        // Sensio/HelloBundle/Author.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints\AssertTrue;
+        
+        class Author
+        {
+
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addGetterConstraint('tokenValid', new AssertTrue(array(
+                    'message' => 'The token is invalid',
+                )));
+            }
+            
+            public function isTokenValid()
+            {
+                // return true or false
+            }
+        }
+
+.. note::
+
+..  The keen-eyed among you will have noticed that the prefix of the getter 
+    ("get" or "is") is omitted in the mapping. This allows you to move the
+    constraint to a property with the same name later (or vice versa) without
+    changing your validation logic.
+
+    鋭い目をお持ちのあなたは、ゲッターの先頭 ("get" あるいは "is") が、マッピングの際には除かれていることにお気付きでしょう。これは、後の (あるいは逆の) 同じ名前を持つプロパティに、バリデーションのロジックを変えることなく制約を移動できるようにするためです。
+
+カスタム制約
+------------------
+
+.. You can create a custom constraint by extending the base constraint class,
+   :class:`Symfony\\Component\\Validator\\Constraint`. Options for your
+   constraint are represented by public properties on the constraint class. For
+   example, the ``Url`` constraint includes ``message`` and ``protocols``
+   properties:
+
+:class:`Symfony\\Component\\Validator\\Constraint` というベースとなる制約クラスを拡張することで、カスタム制約を作ることができます。この制約のオプションは、制約クラスのパブリックなプロパティとして与えられます。例えば、 ``Url`` 制約は ``message`` と ``protocols`` というプロパティーを含みます。
+
+.. code-block:: php
+
+    namespace Symfony\Component\Validator\Constraints;
+
+    class Url extends \Symfony\Component\Validator\Constraint
+    {
+        public $message = 'This value is not a valid URL';
+        public $protocols = array('http', 'https', 'ftp', 'ftps');
+    }
+
+.. As you can see, a constraint class is fairly minimal. The actual validation is
+   performed by a another "constraint validator" class. Which constraint
+   validator is specified by the constraint's ``validatedBy()`` method, which
+   includes some simple default logic:
+
+ご覧の通り、制約クラスはかなり小さいものです。実際のバリデーションは別の「制約バリデータ」のクラスが実行します。制約の ``validatedBy()`` メソッドで定義された制約バリデータは、シンプルなデフォルトのロジックを含んでいます。
+
+.. code-block:: php
+
+    // in the base Symfony\Component\Validator\Constraint class
+    public function validatedBy()
+    {
+        return get_class($this).'Validator';
+    }
+
+依存性付きの制約バリデータ
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. If your constraint validator has dependencies, such as a database connection,
+   it will need to be configured as a service in the dependency injection
+   container. This service must include the ``validator.constraint_validator``
+   tag and an ``alias`` attribute:
+
+データベースへの接続のように、制約バリデータが依存性を持つ場合、依存性インジェクションコンテナ内でサービスとして設定される必要があります。このサービスは、 ``validator.constraint_validator`` タグと ``alias`` 属性を含んでいなければなりません。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        services:
+            validator.unique.your_validator_name:
+                class: Fully\Qualified\Validator\Class\Name
+                tags:
+                    - { name: validator.constraint_validator, alias: alias_name }
+
+    .. code-block:: xml
+
+        <service id="validator.unique.your_validator_name" class="Fully\Qualified\Validator\Class\Name">
+            <argument type="service" id="doctrine.orm.default_entity_manager" />
+            <tag name="validator.constraint_validator" alias="alias_name" />
+        </service>
+
+    .. code-block:: php
+
+        $container
+            ->register('validator.unique.your_validator_name', 'Fully\Qualified\Validator\Class\Name')
+            ->addTag('validator.constraint_validator', array('alias' => 'alias_name'))
+        ;
+
+.. Your constraint class may now use this alias to reference the appropriate
+  validator::
+
+正しいバリデータを参照するため、エイリアスを使うことができます。
+
+    public function validatedBy()
+    {
+        return 'alias_name';
+    }

--- a/book/validator/constraints/AssertFalse.rst
+++ b/book/validator/constraints/AssertFalse.rst
@@ -1,0 +1,23 @@
+AssertFalse
+===========
+
+.. Validates that a value is ``false``.
+
+値が ``false`` であることのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        deleted:
+            - AssertFalse: ~
+
+オプション
+-------
+
+.. * ``message``: The error message if validation fails
+
+* ``message``: バリデーションが失敗した時のエラーメッセージ。
+
+.. See :doc:`AssertTrue <AssertTrue>`.
+
+:doc:`AssertTrue <AssertTrue>` を参照してください。

--- a/book/validator/constraints/AssertTrue.rst
+++ b/book/validator/constraints/AssertTrue.rst
@@ -1,0 +1,114 @@
+AssertTrue
+==========
+
+.. Validates that a value is ``true``.
+
+値が ``true`` であることのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        termsAccepted:
+            - AssertTrue: ~
+
+オプション
+-------
+
+.. * ``message``: The error message if validation fails
+
+* ``message``: バリデーションが失敗した時のエラーメッセージ。
+
+例
+-------
+
+.. This constraint is very useful to execute custom validation logic. You can
+   put the logic in a method which returns either ``true`` or ``false``.
+
+この制約はカスタムバリデーションのロジックを実行する際に非常に役立ちます。 ``true`` または ``false`` を返すメソッドにロジックを入れることができます。
+
+.. code-block:: php
+
+    // Sensio/HelloBundle/Author.php
+    class Author
+    {
+        protected $token;
+
+        public function isTokenValid()
+        {
+            return $this->token == $this->generateToken();
+        }
+    }
+
+.. Then you can constrain this method with ``AssertTrue``.
+
+``AssertTrue`` でこのメソッドに制約をかけることができます。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Author:
+            getters:
+                tokenValid:
+                    - AssertTrue: { message: "トークンは無効です" }
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <getter name="tokenValid">
+                <constraint name="True">
+                    <option name="message">トークンは無効です</option>
+                </constraint>
+            </getter>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            protected $token;
+
+            /**
+             * @validation:AssertTrue(message = "トークンは無効です")
+             */
+            public function isTokenValid()
+            {
+                return $this->token == $this->generateToken();
+            }
+        }
+
+    .. code-block:: php
+
+        // Sensio/HelloBundle/Author.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints\AssertTrue;
+        
+        class Author
+        {
+            protected $token;
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addGetterConstraint('tokenValid', new AssertTrue(array(
+                    'message' => 'トークンは無効です',
+                )));
+            }
+
+            public function isTokenValid()
+            {
+                return $this->token == $this->generateToken();
+            }
+        }
+
+.. If the validation of this method fails, you will see a message similar to
+   this:
+
+このメソッドのバリデーションが失敗した場合、以下のようなメッセージが表示されます。
+
+.. code-block:: text
+
+    Sensio\HelloBundle\Author.tokenValid:
+        This value should not be null

--- a/book/validator/constraints/AssertType.rst
+++ b/book/validator/constraints/AssertType.rst
@@ -1,0 +1,39 @@
+AssertType
+==========
+
+.. Validates that a value has a specific data type
+
+値が指定したデータ型であることのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        age:
+            - AssertType: integer
+
+オプション
+-------
+
+.. * ``type`` (**default**, required): A fully qualified class name or one of the
+    PHP datatypes as determined by PHP's ``is_`` functions.
+
+* ``type`` (**デフォルト**, 必須): 完全修飾のクラス名か、PHPの ``is_`` 関数で定められたPHPのデータ型の1つ。
+
+  * `array <http://php.net/is_array>`_
+  * `bool <http://php.net/is_bool>`_
+  * `callable <http://php.net/is_callable>`_
+  * `float <http://php.net/is_float>`_ 
+  * `double <http://php.net/is_double>`_
+  * `int <http://php.net/is_int>`_ 
+  * `integer <http://php.net/is_integer>`_
+  * `long <http://php.net/is_long>`_
+  * `null <http://php.net/is_null>`_
+  * `numeric <http://php.net/is_numeric>`_
+  * `object <http://php.net/is_object>`_
+  * `real <http://php.net/is_real>`_
+  * `resource <http://php.net/is_resource>`_
+  * `scalar <http://php.net/is_scalar>`_
+  * `string <http://php.net/is_string>`_
+.. * ``message``: The error message in case the validation fails
+
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/Choice.rst
+++ b/book/validator/constraints/Choice.rst
@@ -1,0 +1,190 @@
+Choice
+======
+
+.. Validates that a value is one or more of a list of choices.
+
+値が1つあるいは複数の選択リストであるかのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        gender:
+            - Choice: [male, female]
+
+オプション
+-------
+
+.. * ``choices`` (**default**, required): The available choices
+   * ``callback``: Can be used instead of ``choices``. A static callback method
+     returning the choices. If you pass a string, it is expected to be
+     the name of a static method in the validated class.
+   * ``multiple``: Whether multiple choices are allowed. Default: ``false``
+   * ``min``: The minimum amount of selected choices
+   * ``max``: The maximum amount of selected choices
+   * ``message``: The error message if validation fails
+   * ``minMessage``: The error message if ``min`` validation fails
+   * ``maxMessage``: The error message if ``max`` validation fails
+
+* ``choices`` (**デフォルト**, 必須): 使用可能な選択肢。
+* ``callback``: ``choices`` の代わりに使用可能。選択肢を返すスタティックなコールバックメソッド。文字列を渡すと、バリデーション対象のクラス内のスタティックなメソッド名と想定する。
+* ``multiple``: 複数の選択肢が許可されているかどうか。デフォルト: ``false``
+* ``min``: 選択できる選択肢の最大個数。
+* ``max``: 選択できる選択肢の最大個数。
+* ``message``: バリデーションが失敗した時のエラーメッセージ。
+* ``minMessage``: ``min`` のバリデーションが失敗した時のエラーメッセージ
+* ``maxMessage``: ``max`` のバリデーションが失敗した時のエラーメッセージ
+
+
+例 1: 静的配列としての選択肢
+----------------------------------
+
+.. If the choices are few and easy to determine, they can be passed to the
+   constraint definition as array.
+
+選択肢の数がほとんどなく、簡単に見つけられる場合、配列として制約の定義を渡すことができます。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Author:
+            properties:
+                gender:
+                    - Choice: [male, female]
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <property name="gender">
+                <constraint name="Choice">
+                    <value>male</value>
+                    <value>female</value>
+                </constraint>
+            </property>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /**
+             * @validation:Choice({"male", "female"})
+             */
+            protected $gender;
+        }
+
+    .. code-block:: php
+
+        // Sensio/HelloBundle/Author.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints\Choice;
+        
+        class Author
+        {
+            protected $gender;
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('gender', new Choice(array('male', 'female')));
+            }
+        }
+
+例 2: コールバックからの選択肢
+----------------------------------
+
+.. When you also need the choices in other contexts (such as a drop-down box in
+   a form), it is more flexible to bind them to your domain model using a static
+   callback method.
+
+他のコンテキスト (例えばフォーム内のドロップダウンなど) で選択肢が必要な場合も、それらをスタティックなコールバックメソッドを使用したドメインモデルに柔軟に関連付けることができます。
+
+.. code-block:: php
+
+    // Sensio/HelloBundle/Author.php
+    class Author
+    {
+        public static function getGenders()
+        {
+            return array('male', 'female');
+        }
+    }
+
+.. You can pass the name of this method to the ``callback`` option of the ``Choice``
+   constraint.
+
+メソッド名を ``Choice`` 制約のコールバックオプションに渡すことができます。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Author:
+            properties:
+                gender:
+                    - Choice: { callback: getGenders }
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <property name="gender">
+                <constraint name="Choice">
+                    <option name="callback">getGenders</option>
+                </constraint>
+            </property>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /**
+             * @validation:Choice(callback = "getGenders")
+             */
+            protected $gender;
+        }
+
+.. If the static callback is stored in a different class, for example ``Util``,
+   you can pass the class name and the method as array.
+
+``Util`` のようにスタティックなコールバックが別なクラスに保存される場合、クラス名とメソッドを配列として渡すことができます。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Author:
+            properties:
+                gender:
+                    - Choice: { callback: [Util, getGenders] }
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <property name="gender">
+                <constraint name="Choice">
+                    <option name="callback">
+                        <value>Util</value>
+                        <value>getGenders</value>
+                    </option>
+                </constraint>
+            </property>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /**
+             * @validation:Choice(callback = {"Util", "getGenders"})
+             */
+            protected $gender;
+        }

--- a/book/validator/constraints/Collection.rst
+++ b/book/validator/constraints/Collection.rst
@@ -1,0 +1,145 @@
+Collection
+==========
+
+.. Validates array entries against different constraints.
+
+異なる制約に対する配列のエントリのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    - Collection:
+        fields:
+            key1:
+                - NotNull: ~
+            key2:
+                - MinLength: 10
+
+オプション
+-------
+
+.. * ``fields`` (required): An associative array of array keys and one or more
+     constraints
+   * ``allowMissingFields``: Whether some of the keys may not be present in the
+     array. Default: ``false``
+   * ``allowExtraFields``: Whether the array may contain keys not present in the
+     ``fields`` option. Default: ``false``
+   * ``missingFieldsMessage``: The error message if the ``allowMissingFields``
+     validation fails
+   * ``allowExtraFields``: The error message if the ``allowExtraFields`` validation
+     fails
+
+* ``fields`` (必須): 配列のキーと1つ以上の制約を結合した配列。
+* ``allowMissingFields``: 配列内のいくつかのキーが与えられていないかどうか。デフォルト: ``false``
+* ``allowExtraFields``: 配列が ``fields`` オプションにないキーを含んでいないかどうか。デフォルト: ``false``
+* ``missingFieldsMessage``: ``allowMissingFields`` バリデーションが失敗した時のエラーメッセージ。
+* ``allowExtraFields``: ``allowExtraFields`` バリデーションが失敗した時のエラーメッセージ。
+
+例:
+--------
+
+Let's validate an array with two indexes ``firstName`` and ``lastName``. The 
+value of ``firstName`` must not be blank, while the value of ``lastName`` must 
+not be blank with a minimum length of four characters. Furthermore, both keys
+may not exist in the array.
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Author:
+            properties:
+                options:
+                    - Collection:
+                        fields:
+                            firstName:
+                                - NotBlank: ~
+                            lastName:
+                                - NotBlank: ~
+                                - MinLength: 4
+                        allowMissingFields: true
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <property name="options">
+                <constraint name="Collection">
+                    <option name="fields">
+                        <value key="firstName">
+                            <constraint name="NotNull" />
+                        </value>
+                        <value key="lastName">
+                            <constraint name="NotNull" />
+                            <constraint name="MinLength">4</constraint>
+                        </value>
+                    </option>
+                    <option name="allowMissingFields">true</option>
+                </constraint>
+            </property>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /**
+             * @validation:Collection(
+             *   fields = {
+             *     "firstName" = @validation:NotNull(),
+             *     "lastName" = { @validation:NotBlank(), @validation:MinLength(4) }
+             *   },
+             *   allowMissingFields = true
+             * )
+             */
+            private $options = array();
+        }
+
+    .. code-block:: php
+
+        // Sensio/HelloBundle/Author.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints\Collection;
+        use Symfony\Component\Validator\Constraints\NotNull;
+        use Symfony\Component\Validator\Constraints\NotBlank;
+        use Symfony\Component\Validator\Constraints\MinLength;
+        
+        class Author
+        {
+            private $options = array();
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('options', new Collection(array(
+                    'fields' => array(
+                        'firstName' => new NotNull(),
+                        'lastName' => array(new NotBlank(), new MinLength(4)),
+                    ),
+                    'allowMissingFields' => true,
+                )));
+            }
+        }
+
+.. The following object would fail the validation.
+
+以下のオブジェクトでは、バリデーションは失敗します。
+
+.. code-block:: php
+
+    $author = new Author();
+    $author->options['firstName'] = null;
+    $author->options['lastName'] = 'foo';
+
+    print $validator->validate($author);
+
+.. You should see the following error messages:
+
+以下のエラーメッセージが表示されるでしょう。
+
+.. code-block:: text
+
+    Sensio\HelloBundle\Author.options[firstName]:
+        This value should not be null
+    Sensio\HelloBundle\Author.options[lastName]:
+        This value is too short. It should have 4 characters or more

--- a/book/validator/constraints/Date.rst
+++ b/book/validator/constraints/Date.rst
@@ -1,0 +1,19 @@
+Date
+====
+
+Validates that a value is a valid date string with format "YYYY-MM-DD".
+
+値が "YYYY-MM-DD" フォーマットの日にち文字列であることのバリデートを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        birthday:
+            - Date: ~
+
+オプション
+-------
+
+.. * ``message``: The error message if the validation fails
+
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/DateTime.rst
+++ b/book/validator/constraints/DateTime.rst
@@ -1,0 +1,19 @@
+DateTime
+========
+
+.. Validates that a value is a valid datetime string with format "YYYY-MM-DD HH:MM:SS".
+
+値が "YYYY-MM-DD HH:MM:SS" フォーマットでの有効な日時文字列であることのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        createdAt:
+            - DateTime: ~
+
+オプション
+-------
+
+.. * ``message``: The error message if the validation fails
+
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/Email.rst
+++ b/book/validator/constraints/Email.rst
@@ -1,0 +1,21 @@
+Email
+=====
+
+.. Validates that a value is a valid email address.
+
+値が有効なEメールアドレスであることのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        email:
+            - Email: ~
+
+オプション
+-------
+
+.. * ``checkMX``: Whether MX records should be checked for the domain. Default: ``false``
+   * ``message``: The error message if the validation fails
+
+* ``checkMX``: ドメインに対してMXレコードをチェックすべきかどうか。デフォルト: ``false``
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/File.rst
+++ b/book/validator/constraints/File.rst
@@ -1,0 +1,107 @@
+File
+====
+
+.. Validates that a value is the path to an existing file.
+
+値が存在するファイルのパスであることのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        filename:
+            - File: ~
+
+オプション
+-------
+
+.. * ``maxSize``: The maximum allowed file size. Can be provided in bytes, kilobytes
+     (with the suffix "k") or megabytes (with the suffix "M")
+   * ``mimeTypes``: One or more allowed mime types
+   * ``notFoundMessage``: The error message if the file was not found
+   * ``notReadableMessage``: The error message if the file could not be read
+   * ``maxSizeMessage``: The error message if ``maxSize`` validation fails
+   * ``mimeTypesMessage``: The error message if ``mimeTypes`` validation fails
+
+* ``maxSize``: 許されている最大ファイルサイズ。バイト単位、キロバイト単位 (末尾に "k") 、メガバイト単位 (末尾に "M") で表せます。
+* ``mimeTypes``: 許されている1つまたは複数の MIME タイプ。
+* ``notFoundMessage``: ファイルが見つからない場合のエラーメッセージ。
+* ``notReadableMessage``: ファイルが読み込みできない場合のエラーメッセージ。
+* ``maxSizeMessage``: ``maxSize`` バリデーションが失敗した場合のエラーメッセージ
+* ``mimeTypesMessage``: ``mimeTypes`` バリデーションが失敗した場合のエラーメッセージ
+
+例: ファイルサイズと MIME タイプのバリデーションを行う
+-----------------------------------------------
+
+.. In this example we use the ``File`` constraint to verify that the file does
+   not exceed a maximum size of 128 kilobytes and is a PDF document.
+
+この例では、ファイルが 128KB の最大サイズを超えていないことと、PDF ドキュメントであることを検証するために、 ``File`` 制約を使います。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        properties:
+            filename:
+                - File: { maxSize: 128k, mimeTypes: [application/pdf, application/x-pdf] }
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <property name="filename">
+                <constraint name="File">
+                    <option name="maxSize">128k</option>
+                    <option name="mimeTypes">
+                        <value>application/pdf</value>
+                        <value>application/x-pdf</value>
+                    </option>
+                </constraint>
+            </property>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /**
+             * @validation:File(maxSize = "128k", mimeTypes = {
+             *   "application/pdf",
+             *   "application/x-pdf"
+             * })
+             */
+            private $filename;
+        }
+
+    .. code-block:: php
+
+        // Sensio/HelloBundle/Author.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints\File;
+        
+        class Author
+        {
+            private $filename;
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('filename', new File(array(
+                    'maxSize' => '128k',
+                    'mimeTypes' => array(
+                        'application/pdf',
+                        'application/x-pdf',
+                    ),
+                )));
+            }
+        }
+
+.. When you validate the object with a file that doesn't satisfy one of these
+   constraints, a proper error message is returned by the validator:
+
+これらの制約の1つを満たさないファイルを持つオブジェクトのバリデーションを行うと、しかるべきエラーメッセージがバリデータから返されます。
+
+.. code-block:: text
+
+    Sensio\HelloBundle\Author.filename:
+        The file is too large (150 kB). Allowed maximum size is 128 kB

--- a/book/validator/constraints/Max.rst
+++ b/book/validator/constraints/Max.rst
@@ -1,0 +1,21 @@
+Max
+===
+
+.. Validates that a value is not greater than the given limit.
+
+与えられた制限値よりも値が大きくないことのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        age:
+            - Max: 99
+
+オプション
+-------
+
+.. * ``limit`` (**default**, required): The limit
+   * ``message``: The error message if validation fails
+
+* ``limit`` (**デフォルト**, 必須): 制限値。
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/MaxLength.rst
+++ b/book/validator/constraints/MaxLength.rst
@@ -1,0 +1,21 @@
+MaxLength
+=========
+
+.. Validates that the string length of a value is not greater than the given limit.
+
+与えられた制限値よりも文字列の長さが長くないことのバリデートを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        firstName:
+            - MaxLength: 20
+
+オプション
+-------
+
+.. * ``limit`` (**default**, required): The limit
+   * ``message``: The error message if validation fails
+
+* ``limit`` (**デフォルト**, 必須): 制限値。
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/Min.rst
+++ b/book/validator/constraints/Min.rst
@@ -1,0 +1,21 @@
+Min
+===
+
+.. Validates that a value is not smaller than the given limit.
+
+与えられた制限値よりも値が小さくないことのバリデートを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        age:
+            - Min: 1
+
+オプション
+-------
+
+.. * ``limit`` (**default**, required): The limit
+   * ``message``: The error message if validation fails
+
+* ``limit`` (**デフォルト**, 必須): 制限値。
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/MinLength.rst
+++ b/book/validator/constraints/MinLength.rst
@@ -1,0 +1,21 @@
+MinLength
+=========
+
+.. Validates that the string length of a value is not smaller than the given limit.
+
+与えられた制限値よりも文字列の長さが短いことのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        firstName:
+            - MinLength: 3
+
+オプション
+-------
+
+.. * ``limit`` (**default**, required): The limit
+   * ``message``: The error message if validation fails
+
+* ``limit`` (**デフォルト**, 必須): 制限値。
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/NotBlank.rst
+++ b/book/validator/constraints/NotBlank.rst
@@ -1,0 +1,20 @@
+NotBlank
+========
+
+.. Validates that a value is not empty (as determined by the `empty
+   <http://php.net/empty>`_ construct).
+
+値が空でないことのバリデーションを実行します。 ( `empty <http://php.net/empty>`_ 定数によって判断されます)
+
+.. code-block:: yaml
+
+    properties:
+        firstName:
+            - NotBlank: ~
+
+オプション
+-------
+
+.. * ``message``: The error message if validation fails
+
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/NotNull.rst
+++ b/book/validator/constraints/NotNull.rst
@@ -1,0 +1,19 @@
+NotNull
+=======
+
+.. Validates that a value is not ``null``.
+
+値が ``null`` でないことのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        firstName:
+            - NotNull: ~
+
+オプション
+-------
+
+.. * ``message``: The error message if validation fails
+
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/Regex.rst
+++ b/book/validator/constraints/Regex.rst
@@ -1,0 +1,24 @@
+Regex
+=====
+
+.. Validates that a value matches a regular expression.
+
+値が正規表現にマッチするかのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        title:
+            - Regex: /\w+/
+
+オプション
+-------
+
+.. * ``pattern`` (**default**, required): The regular expression pattern
+   * ``match``: Whether the pattern must be matched or must not be matched.
+     Default: ``true``
+   * ``message``: The error message if validation fails
+
+* ``pattern`` (**デフォルト**, 必須): 正規表現のパターン。
+* ``match``: パターンがマッチしなければならないかどうか。デフォルト: ``true``
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/Time.rst
+++ b/book/validator/constraints/Time.rst
@@ -1,0 +1,19 @@
+Time
+====
+
+.. Validates that a value is a valid time string with format "HH:MM:SS".
+
+値が "HH:MM:SS" のフォーマットを持つ有効な時間の文字列であることのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        createdAt:
+            - DateTime: ~
+
+オプション
+-------
+
+.. * ``message``: The error message if the validation fails
+
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/Url.rst
+++ b/book/validator/constraints/Url.rst
@@ -1,0 +1,22 @@
+Url
+===
+
+.. Validates that a value is a valid URL string.
+
+値が有効なURL文字列であることのバリデーションを実行します。
+
+.. code-block:: yaml
+
+    properties:
+        website:
+            - Url: ~
+
+オプション
+-------
+
+.. * ``protocols``: A list of allowed protocols. Default: "http", "https", "ftp"
+      and "ftps".
+   * ``message``: The error message if validation fails
+
+* ``protocols``: 許可されるプロトコルの一覧。デフォルトでは、"http", "https", "ftp", "ftps"
+* ``message``: バリデーションが失敗した時のエラーメッセージ。

--- a/book/validator/constraints/Valid.rst
+++ b/book/validator/constraints/Valid.rst
@@ -1,0 +1,223 @@
+Valid
+=====
+
+.. Marks an associated object to be validated itself.
+
+関連したオブジェクトそれ自体のバリデーションが実施されるようにマークします。
+
+.. code-block:: yaml
+
+    properties:
+        address:
+            - Valid: ~
+
+例: オブジェクトグラフをバリデーション
+-------------------------------
+
+.. This constraint helps to validate whole object graphs. In the following example,
+   we create two classes ``Author`` and ``Address`` that both have constraints on
+   their properties. Furthermore, ``Author`` stores an ``Address`` instance in the
+   ``$address`` property.
+
+この制約はオブジェクトグラフ全体のバリデーションを実施するのに役立ちます。以下の例では、それぞれがプロパティに制約を持っている ``Author`` と ``Address`` という2つのクラスを作成します。さらに、 ``Author`` は ``Address`` インスタンスを ``$address`` プロパティに保存します。
+
+.. code-block:: php
+
+    // Sensio/HelloBundle/Address.php
+    class Address
+    {
+        protected $street;
+        protected $zipCode;
+    }
+
+.. code-block:: php
+
+    // Sensio/HelloBundle/Author.php
+    class Author
+    {
+        protected $firstName;
+        protected $lastName;
+        protected $address;
+    }
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Address:
+            properties:
+                street:
+                    - NotBlank: ~
+                zipCode:
+                    - NotBlank: ~
+                    - MaxLength: 5
+
+        Sensio\HelloBundle\Author:
+            properties:
+                firstName:
+                    - NotBlank: ~
+                    - MinLength: 4
+                lastName:
+                    - NotBlank: ~
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Address">
+            <property name="street">
+                <constraint name="NotBlank" />
+            </property>
+            <property name="zipCode">
+                <constraint name="NotBlank" />
+                <constraint name="MaxLength">5</constraint>
+            </property>
+        </class>
+
+        <class name="Sensio\HelloBundle\Author">
+            <property name="firstName">
+                <constraint name="NotBlank" />
+                <constraint name="MinLength">4</constraint>
+            </property>
+            <property name="lastName">
+                <constraint name="NotBlank" />
+            </property>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Address.php
+        class Address
+        {
+            /**
+             * @validation:NotBlank()
+             */
+            protected $street;
+
+            /**
+             * @validation:NotBlank
+             * @validation:MaxLength(5)
+             */
+            protected $zipCode;
+        }
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /**
+             * @validation:NotBlank
+             * @validation:MinLength(4)
+             */
+            protected $firstName;
+
+            /**
+             * @validation:NotBlank
+             */
+            protected $lastName;
+            
+            protected $address;
+        }
+
+    .. code-block:: php
+
+        // Sensio/HelloBundle/Address.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints\NotBlank;
+        use Symfony\Component\Validator\Constraints\MaxLength;
+        
+        class Address
+        {
+            protected $street;
+
+            protected $zipCode;
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('street', new NotBlank());
+                $metadata->addPropertyConstraint('zipCode', new NotBlank());
+                $metadata->addPropertyConstraint('zipCode', new MaxLength(5));
+            }
+        }
+
+        // Sensio/HelloBundle/Author.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints\NotBlank;
+        use Symfony\Component\Validator\Constraints\MinLength;
+        
+        class Author
+        {
+            protected $firstName;
+
+            protected $lastName;
+            
+            protected $address;
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('firstName', new NotBlank());
+                $metadata->addPropertyConstraint('firstName', new MinLength(4));
+                $metadata->addPropertyConstraint('lastName', new NotBlank());
+            }
+        }
+
+.. With this mapping it is possible to successfully validate an author with an
+   invalid address. To prevent that, we add the ``Valid`` constraint to the
+   ``$address`` property.
+
+このマッピングでは、不正なアドレスで著者名のバリデーションが成功してしまう可能性があります。これを防ぐために、 ``Valid`` 制約を ``$address`` プロパティに追加します。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Author:
+            properties:
+                address:
+                    - Valid: ~
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <property name="address">
+                <constraint name="Valid" />
+            </property>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /* ... */
+            
+            /**
+             * @validation:Valid
+             */
+            protected $address;
+        }
+
+    .. code-block:: php
+
+        // Sensio/HelloBundle/Author.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Component\Validator\Constraints\Valid;
+        
+        class Author
+        {
+            protected $address;
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('address', new Valid());
+            }
+        }
+
+.. If you validate an author with an invalid address now, you can see that the
+   validation of the ``Address`` fields failed.
+
+不正なアドレスで著者名をバリデーションにかけると、 ``Address`` フィールドのバリデーションが失敗することが分かります。
+
+    Sensio\HelloBundle\Author.address.zipCode:
+        This value is too long. It should have 5 characters or less

--- a/book/validator/constraints/index.rst
+++ b/book/validator/constraints/index.rst
@@ -1,0 +1,25 @@
+Symfony2 バリデータ制約
+==============================
+
+.. toctree::
+   :maxdepth: 1
+
+   AssertFalse
+   AssertTrue
+   AssertType
+   Choice
+   Collection
+   Date
+   DateTime
+   Email
+   File
+   Max
+   MaxLength
+   Min
+   MinLength
+   NotBlank
+   NotNull
+   Regex
+   Time
+   Url
+   Valid

--- a/book/validator/index.rst
+++ b/book/validator/index.rst
@@ -1,0 +1,9 @@
+Symfony2 バリデータ
+==================
+
+.. toctree::
+   :maxdepth: 2
+
+   概要 <overview>
+   バリデーション <validation>
+   制約 <constraints>

--- a/book/validator/overview.rst
+++ b/book/validator/overview.rst
@@ -1,0 +1,119 @@
+バリデーション
+=============
+
+.. Validation is a very common task in web applications. Data entered in forms
+   needs to be validated. Data also needs to be validated before it is written
+   into a database or passed to a web service.
+
+バリデーションは Web アプリケーションでは非常に一般的なタスクです。フォームに入力されたデータはバリデーションを通す必要があります。また、データベースへ保存したり他の Web サービスに渡したりする前にもバリデーションを行う必要があります。
+
+.. Symfony2 ships with a Validator component that makes this task very easy. This
+   component is based on the `JSR303 Bean Validation specification`_. What? A
+   Java specification in PHP? You heard right, but it's not as bad as it sounds.
+   Let's look at how we use it in PHP.
+
+Symfony2 は、バリデーションのタスクを簡単にするための Validator コンポーネントを備えています。このコンポーネントは `JSR303 Bean Validation specification`_ が元になっています。`JSR303 Bean Validation specification`_ って何？ PHP で書いた Java の仕様？ それも間違いではありません。しかし、聞くほど悪いものではありません。これから、それを PHP でどのように使うのかを見ていきましょう。
+
+.. The validator validates objects against :doc:`constraints <constraints>`.
+   Let's start with the simple constraint that the ``$name`` property of a class
+   ``Author`` must not be empty::
+
+バリデータは :doc:`制約 <constraints>` に対してオブジェクトのバリデーションを行います。 ``Author`` クラスのプロパティである ``$name`` が空ではないことを要求する簡単な制約から始めましょう。
+
+    // Sensio/HelloBundle/Author.php
+    class Author
+    {
+        private $name;
+    }
+
+.. The next listing shows the configuration that connects properties of the class
+   with constraints; this process is called the "mapping":
+
+次の例は、クラスのプロパティと制約を関連付ける設定を表しています。このプロセスを、「マッピング」と呼びます。
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # Sensio/HelloBundle/Resources/config/validation.yml
+        Sensio\HelloBundle\Author:
+            properties:
+                name:
+                    - NotBlank: ~
+
+    .. code-block:: xml
+
+        <!-- Sensio/HelloBundle/Resources/config/validation.xml -->
+        <class name="Sensio\HelloBundle\Author">
+            <property name="name">
+                <constraint name="NotBlank" />
+            </property>
+        </class>
+
+    .. code-block:: php-annotations
+
+        // Sensio/HelloBundle/Author.php
+        class Author
+        {
+            /**
+             * @validation:NotBlank()
+             */
+            private $name;
+        }
+
+    .. code-block:: php
+
+        // Sensio/HelloBundle/Author.php
+        use Symfony\Component\Validator\Mapping\ClassMetadata;
+        use Symfony\Components\Validator\Constraints\NotBlank;
+
+        class Author
+        {
+            private $name;
+            
+            public static function loadValidatorMetadata(ClassMetadata $metadata)
+            {
+                $metadata->addPropertyConstraint('name', new NotBlank());
+            }
+        }
+
+.. Finally, we can use the :class:`Symfony\\Component\\Validator\\Validator`
+   class for :doc:`validation <validation>`. To use the default Symfony2
+   validator, adapt your application configuration as follows:
+
+ここでようやく :doc:`validation <validation>` の :class:`Symfony\\Component\\Validator\\Validator` クラスを使用できます。 Symfony2 のデフォルトのバリデータを使用するには、アプリケーションの設定を以下のように行う必要があります。
+
+.. code-block:: yaml
+
+    # hello/config/config.yml
+    framework:
+        validation:
+            enabled: true
+
+.. Now call the ``validate()`` method on the service, which delivers a list of
+.. errors if validation fails.
+
+バリデーションに失敗したときにエラーのリストを送信するため、ここでサービス上で ``validate()`` メソッドを呼び出してください。
+
+.. code-block:: php
+
+    $validator = $container->get('validator');
+    $author = new Author();
+
+    print $validator->validate($author);
+
+.. Because the ``$name`` property is empty, you will see the following error
+   message:
+
+``$name`` プロパティが空なので、以下のエラーメッセージが表示されます。
+
+.. code-block:: text
+
+    Sensio\HelloBundle\Author.name:
+        This value should not be blank
+
+.. Insert a value into the property and the error message will disappear.
+
+プロパティに値を入れると、エラーメッセージは消えます。
+
+.. _JSR303 Bean Validation specification: http://jcp.org/en/jsr/detail?id=303

--- a/book/validator/validation.rst
+++ b/book/validator/validation.rst
@@ -1,0 +1,55 @@
+制約のバリデーション
+=====================
+
+.. Objects with constraints are validated by the
+   :class:`Symfony\\Component\\Validator\\Validator` class. If you use Symfony2,
+   this class is already registered as a service in the Dependency Injection
+   Container. To enable the service, add the following lines to your
+   configuration:
+
+制約付きのオブジェクトは、 :class:`Symfony\\Component\\Validator\\Validator` によってバリデーションが行われます。 Symfony2 を使用している場合、このクラスは DI コンテナ内であらかじめサービスとして登録されています。サービスを使用可能にするには、以下の行を設定に追加してください。
+
+.. code-block:: yaml
+
+    # hello/config/config.yml
+    framework:
+        validation:
+            enabled: true
+
+.. Then you can get the validator from the container and start validating your
+   objects:
+
+これでコンテナからバリデータを使用可能にし、オブジェクトのバリデーションを開始できます。
+
+.. code-block:: php
+
+    $validator = $container->get('validator');
+    $author = new Author();
+
+    print $validator->validate($author);
+
+.. The ``validate()`` method returns a
+   :class:`Symfony\\Component\\Validator\\ConstraintViolationList` object. This
+   object behaves exactly like an array. You can iterate over it and you can even
+   print it in a nicely formatted manner. Every element of the list corresponds
+   to one validation error. If the list is empty, it's time to dance, because
+   then validation succeeded.
+
+``validate()`` メソッドは、 :class:`Symfony\\Component\\Validator\\ConstraintViolationList` クラスを返します。このオブジェクトはまさしく配列のように振舞います。イテレートすることもできますし、きれいに整形されたかたちで表示することもできてしまいます。リストのそれぞれの要素は、1つのバリデーションのエラーに対応します。リストが空の時は、ダンスしましょう。バリデーションが成功したということですから。
+
+.. The above call will output something similar to this:
+
+上に挙げた呼び出しは、以下と同じような出力を返します。
+
+.. code-block:: text
+
+    Sensio\HelloBundle\Author.firstName:
+        This value should not be blank
+    Sensio\HelloBundle\Author.lastName:
+        This value should not be blank
+    Sensio\HelloBundle\Author.fullName:
+        This value is too short. It should have 10 characters or more
+
+.. If you fill the object with correct values the validation errors disappear.
+
+オブジェクトに正しい値を入れた場合、バリデーションのエラーは消えます。


### PR DESCRIPTION
Validator部分の翻訳を行いましたので、プルリクエストします。
Validatorを「バリデータ」とするのは、Jobeetなど1.xのドキュメントと同じなので問題ないのですが、「バリデート」と「バリデーション」の使い分けをなるべくしたくなかったので、後者にできるだけ統一してみました。
