### PR TITLE
[cookbook][email] added japanese translation for email articles.

### DIFF
--- a/cookbook/email.rst
+++ b/cookbook/email.rst
@@ -1,5 +1,129 @@
-このページの翻訳はまだ行われていません。
-========================================
+.. index::
+   single: Emails
 
-翻訳にご協力くださる方は
-`github/symfony-japan <https://github.com/symfony-japan/symfony-docs-ja/wiki>`_ まで！
+メールの送信方法
+====================
+
+メール送信は、ウェブアプリケーションを作る際のよくある困難なタスクです。機能を実装するのに、車輪の再発明をするのではなく、 `SwiftMailer`_ ライブラリを活用した ``SwiftmailerBundle`` を使用してメール送信機能を実装することができます。
+
+.. note::
+
+   使用する前に、 ``SwiftmailerBundle`` バンドルを使用可能にしていることを確認してください。
+   ::
+
+        public function registerBundles()
+        {
+            $bundles = array(
+                // ...
+                new Symfony\Bundle\SwiftmailerBundle\SwiftmailerBundle(),
+            );
+
+            // ...
+        }
+
+.. _swift-mailer-configuration:
+
+コンフィギュレーション
+-------------
+
+Swiftmailer を使用する前に、コンフィギュレーションをチェックしましょう。指定が必要なパラメターは、 ``transport`` だけです。
+:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        swiftmailer:
+            transport:  smtp
+            encryption: ssl
+            auth_mode:  login
+            host:       smtp.gmail.com
+            username:   your_username
+            password:   your_password
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+
+        <!--
+        xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+        http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd
+        -->
+
+        <swiftmailer:config
+            transport="smtp"
+            encryption="ssl"
+            auth-mode="login"
+            host="smtp.gmail.com"
+            username="your_username"
+            password="your_password" />
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container->loadFromExtension('swiftmailer', array(
+            'transport'  => "smtp",
+            'encryption' => "ssl",
+            'auth_mode'  => "login",
+            'host'       => "smtp.gmail.com",
+            'username'   => "your_username",
+            'password'   => "your_password",
+        ));
+
+Swiftmailer コンフィギュレーションのほとんどは、メッセージの配送方法に関するものです。
+
+次のコンフィギュレーションを指定することができます。
+:
+
+* ``transport``         (``smtp``, ``mail``, ``sendmail``, or ``gmail``)
+* ``username``
+* ``password``
+* ``host``
+* ``port``
+* ``encryption``        (``tls``, or ``ssl``)
+* ``auth_mode``         (``plain``, ``login``, or ``cram-md5``)
+* ``spool``
+
+  * ``type`` (現在は ``file`` のみを指定えきますが、どうやってキューを行うかを指定します)
+  * ``path`` (メッセージを格納する場所)
+* ``delivery_address``  (全てのメールを送るメールアドレス)
+* ``disable_delivery``  (配送の失敗を許容するには true を指定してください)
+
+メールの送信
+--------------
+
+Swiftmailer ライブラリは、 ``Swift_Message`` オブジェクトを作成し、設定し、そして送信することで動作をします。 ``mailer`` は実際のメッセージの配送に対して責任を持って、 ``mailer`` サービスを介してアクセスが可能です。結果、メールの送信は素直な実装になります。
+::
+
+    public function indexAction($name)
+    {
+        $message = \Swift_Message::newInstance()
+            ->setSubject('Hello Email')
+            ->setFrom('send@example.com')
+            ->setTo('recipient@example.com')
+            ->setBody($this->renderView('HelloBundle:Hello:email.txt.twig', array('name' => $name)))
+        ;
+        $this->get('mailer')->send($message);
+
+        return $this->render(...);
+    }
+
+疎な結合をするために、 メールの本文は、テンプレートに格納され、 ``renderView()`` メソッドで内容を作成しています。
+
+``$message`` オブジェクトは、添付ファイルや、 HTML コンテントを追加したりするなど、さらに多くのオプションをサポートします。幸運なことに Swiftmailer のドキュメントは充実しており、 `Creating Message` の章を参照して、詳細を調べることができます。
+
+.. tip::
+
+    また、 Symfony2 でのメール送信に関する情報は、他のクックブックの記事も参考になります。
+    :
+
+    * :doc:`gmail`
+    * :doc:`email/dev_environment`
+    * :doc:`email/spool`
+
+.. _`Swiftmailer`: http://www.swiftmailer.org/
+.. _`Creating Messages`: http://swiftmailer.org/docs/messages
+
+.. 2011/10/31 ganchiku 99eb43fff504594b2cea44a137939140620d26c4
+

--- a/cookbook/email/dev_environment.rst
+++ b/cookbook/email/dev_environment.rst
@@ -1,0 +1,104 @@
+開発中におけるメール送信の扱い方
+==========================================
+
+メールを送信するアプリケーションを作成している際に、開発中では、実際に受信者にメールを送信したくないときもあると思います。 Symfony2 の ``SwiftmailerBundle`` を使用すれば、コードの変更をすることなしに、コンフィギュレーションの設定を変更するだけで、この問題を簡単に解決することができます。開発中では、メール送信の処理に関して、主に２つの選択をすることができます。: (a) メール送信を無効にする (b) 特定のメールアドレスにメールを送信する
+
+メール送信を無効にする
+-----------------
+
+``disable_delivery`` オプションを ``true`` に設定すればメール送信を無効にすることができます。 Symfony の Standard Distribution の ``test`` 環境では、デフォルトでメール送信を無効にしており、この設定になっています。 ``test`` 環境でこのようによう指定しているため、テストを実行する際にメールは送信されません。しかし、 ``prod`` や ``dev`` 環境では、送信されます。
+:
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config_test.yml
+        swiftmailer:
+            disable_delivery:  true
+
+    .. code-block:: xml
+
+        <!-- app/config/config_test.xml -->
+
+        <!--
+        xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+        http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd
+        -->
+
+        <swiftmailer:config
+            disable-delivery="true" />
+
+    .. code-block:: php
+
+        // app/config/config_test.php
+        $container->loadFromExtension('swiftmailer', array(
+            'disable_delivery'  => "true",
+        ));
+
+``dev`` 環境でも送信を無効にしたい際には、 ``config_dev.yml`` ファイルに同じ設定を追加するだけです。
+
+特定のメールアドレスに送信する
+------------------------------
+
+また、メッセージを送信する際に、実際に指定したメールアドレスではなく、全てのメールの送信先を特定のアドレスにすることもできます。 ``delivery_address`` オプションを使用してこの設定ができます。
+:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config_dev.yml
+        swiftmailer:
+            delivery_address:  dev@example.com
+
+    .. code-block:: xml
+
+        <!-- app/config/config_dev.xml -->
+
+        <!--
+        xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+        http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd
+        -->
+
+        <swiftmailer:config
+            delivery-address="dev@example.com" />
+
+    .. code-block:: php
+
+        // app/config/config_dev.php
+        $container->loadFromExtension('swiftmailer', array(
+            'delivery_address'  => "dev@example.com",
+        ));
+
+そして、次のように ``recipient@example.com`` にメールを送信しようとしてみます。
+
+.. code-block:: php
+
+    public function indexAction($name)
+    {
+        $message = \Swift_Message::newInstance()
+            ->setSubject('Hello Email')
+            ->setFrom('send@example.com')
+            ->setTo('recipient@example.com')
+            ->setBody($this->renderView('HelloBundle:Hello:email.txt.twig', array('name' => $name)))
+        ;
+        $this->get('mailer')->send($message);
+
+        return $this->render(...);
+    }
+
+``dev`` 環境では、メールは、 ``recipient@example.com`` には送信されずに ``dev@example.com`` に送信されます。 Swiftmailer は、置き換えられたアドレスを ``X-Swfit-To`` に指定して、メールのヘッダーに追加します。そうすることによって、実際に送信したかったアドレスを参照することができます。
+
+.. note::
+
+    ``to`` に指定したアドレスのみならず、 ``CC`` や ``BCC`` に指定したアドレスにも送信されることはありません。 Swiftmailer はこれらのアドレスを上書きして、 ``CC`` であれば、 ``X-Swift-Cc`` に、 ``BCC`` であれば、 ``X-Swift-BCC`` としてメールヘッダに追加します。
+
+ウェブデバッグツールバーで参照する
+----------------------------------
+
+``dev`` 環境を使用していれば、そのページで送信されたメールは、ウェブデバッグツールバーを使って参照することができます。ツールバーのメールアイコンは送信したメールの数を表しています。そのアイコンをクリックすると、メールの詳細のレポートを見ることができます。
+
+メール送信後、すぐにリダイレクトをする場合は、 ``config_dev.yml`` ファイルの ``intercept_redirects`` オプションを ``true`` にすれば、リダイレクトする前のメールをウェブでバッグツールバーで参照することができます。
+
+.. 2011/10/31 ganchiku 3db3df5db2c9150678d1f968683b33bd11809a4b
+

--- a/cookbook/email/spool.rst
+++ b/cookbook/email/spool.rst
@@ -1,0 +1,79 @@
+メールをスプールする方法
+==================
+
+``SwiftmailerBundle`` を使用してSymfony2 のアプリケーションからメールを送信する際に、デフォルトでは、すぐにメールを送信する設定になっています。しかし、 ``Swfitmailer`` とメールトランスポートのコミュニケーションによるパフォーマンス低下は避けた方が良いときもあるでしょう。次のページをロードするのに、メール送信に時間がかかってしまえば、ユーザは待たなければならないですから。この問題を避けるために、メールを直接送信するのではなく、 "spool" を選択することができます。つまり、 ``Swiftmailer`` がメールを送信しようとするのではなく、ファイルなどにメッセージを保存します。そして、他のプロセスがスプールを読み、メールの送信の面倒をみます。現時点の ``Swfitmailer`` では、ファイルへのスプールのみを対応しています。
+
+スプールを使用するために、コンフィギュレーションを次のようにしてください。
+:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config.yml
+        swiftmailer:
+            # ...
+            spool:
+                type: file
+                path: /path/to/spool
+
+    .. code-block:: xml
+
+        <!-- app/config/config.xml -->
+
+        <!--
+        xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+        http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd
+        -->
+
+        <swiftmailer:config>
+             <swiftmailer:spool
+                 type="file"
+                 path="/path/to/spool" />
+        </swiftmailer:config>
+
+    .. code-block:: php
+
+        // app/config/config.php
+        $container->loadFromExtension('swiftmailer', array(
+             // ...
+            'spool' => array(
+                'type' => 'file',
+                'path' => '/path/to/spool',
+            )
+        ));
+
+.. tip::
+
+    スプールをあなたのプロジェクトのディレクトリ内に保存するには、プロジェクトのルートへの参照ができる `%kernel.root_dir%` パラメターを使用してください。
+    :
+
+    .. code-block:: yaml
+
+        path: %kernel.root_dir%/spool
+
+これで、あなたのアプリケーションがメールを「送信」すれば、実際に送信するのではなく、スプールに追加されるようになりました。スプールからのメッセージの送信を非同期にすることができるようになりました。そして、次のようにスプール内のメッセージを送信するコンソールコマンドがあります。
+:
+
+.. code-block:: bash
+
+    php app/console swiftmailer:spool:send
+
+オプションとして送信するメッセージの数を指定することができます。
+:
+
+.. code-block:: bash
+
+    php app/console swiftmailer:spool:send --message-limit=10
+
+また、秒ごとの送信数を指定することもできます。
+:
+
+.. code-block:: bash
+
+    php app/console swiftmailer:spool:send --time-limit=10
+
+実際には、このコマンドを主導で実行したいとは思わないでしょう。その際には、 cron ジョブやスケジュールタスクなどを使用してコマンドをトリガーし、定期間隔による実行をしてください。
+
+.. 2011/10/31 ganchiku c3ffbfba2c139ece7b0160b6cb8f2b3d6fb93482
+

--- a/cookbook/gmail.rst
+++ b/cookbook/gmail.rst
@@ -1,5 +1,56 @@
-このページの翻訳はまだ行われていません。
-========================================
+.. index::
+   single: Emails; Gmail
 
-翻訳にご協力くださる方は
-`github/symfony-japan <https://github.com/symfony-japan/symfony-docs-ja/wiki>`_ まで！
+Gmail を使用してメールを送信する方法
+===============================
+
+開発環境では、 SMTP サーバを使用してメールを送信するよりも、 Gmail を使用した方が簡単で実践的です。 Swfitmailer バンドルを使用すれば、Gmail を使用したメール送信を簡単に実現できます。
+
+.. tip::
+
+    普段使用している Gmail のアカウントをそのまま使用するのではなく、特別なアカウントを作成することをお勧めします。 
+
+次のように、開発環境のコンフィギュレーションファイルの、 ``transport`` の設定を ``gmail`` に変更して、 ``username`` と ``password`` をそのアカウント用のものに指定してください。
+:
+
+.. configuration-block::
+
+    .. code-block:: yaml
+
+        # app/config/config_dev.yml
+        swiftmailer:
+            transport: gmail
+            username:  your_gmail_username
+            password:  your_gmail_password
+
+    .. code-block:: xml
+
+        <!-- app/config/config_dev.xml -->
+
+        <!--
+        xmlns:swiftmailer="http://symfony.com/schema/dic/swiftmailer"
+        http://symfony.com/schema/dic/swiftmailer http://symfony.com/schema/dic/swiftmailer/swiftmailer-1.0.xsd
+        -->
+
+        <swiftmailer:config
+            transport="gmail"
+            username="your_gmail_username"
+            password="your_gmail_password" />
+
+    .. code-block:: php
+
+        // app/config/config_dev.php
+        $container->loadFromExtension('swiftmailer', array(
+            'transport' => "gmail",
+            'username'  => "your_gmail_username",
+            'password'  => "your_gmail_password",
+        ));
+
+これだけです！
+
+.. note::
+
+    ``gmail`` トランスポートは、単なるショートカットで、実際は、 ``smtp`` トランスポートを使用し、 ``encription`` 、 ``auth_mode`` 、 ``host`` を Gmail 用にしたものになります。
+
+.. 2011/10/31 ganchiku c27197749719c196db039a93ecb06f391272cd61
+


### PR DESCRIPTION
「メールの送信方法」
「Gmail を使用してメールを送信する方法」
「開発中におけるメール送信の扱い方」
「メールをスプールする方法」
を翻訳しました。
