### PR TITLE
components/debug の翻訳を行いました。

### DIFF
--- a/components/debug.rst
+++ b/components/debug.rst
@@ -18,7 +18,7 @@ Debugコンポーネント
 Debugコンポーネントは以下の2つの方法でインストールができます。
 
 * 公式Gitリポジトリ (https://github.com/symfony/Debug);
-* Composerを使ってインストール (`Packagist`の ``symfony/debug``).
+* Composerを使ってインストール (\ `Packagist` の ``symfony/debug``\ ).
 
 使い方
 ------


### PR DESCRIPTION
翻訳しました。

更新日時 github ID ソースのgitコミットID
について質問です。
新規に作成した場合も記載するのでしょうか？その場合本家`symfony/symfony-docs`のコミットIDでよろしいのでしょうか？
また、Wikiにはファイル先頭と書いてありますが他のファイルを見ると末尾に書いてあったので今回は末尾に追記しました。
