### PR TITLE
cookbook/doctrine/reverse_engineeringに翻訳更新日と対象バージョン追加

### DIFF
--- a/cookbook/doctrine/reverse_engineering.rst
+++ b/cookbook/doctrine/reverse_engineering.rst
@@ -1,6 +1,12 @@
 .. index::
    single: Doctrine; Generating entities from existing database
 
+.. note::
+
+    * 対象バージョン：2.3+
+    * 翻訳更新日：2014/02/19
+
+
 既にあるデータベースからエンティティを生成する方法
 ==================================================
 


### PR DESCRIPTION
昨日のPR時に漏れてました。お手数ですがよろしくお願いします。
