### PR TITLE
[cookbook] プロファイラーの翻訳の修正点を対応

### DIFF
--- a/cookbook/index.rst
+++ b/cookbook/index.rst
@@ -16,13 +16,13 @@
     form/file_uploads
     logging/channels_handlers
     logging/monolog_email
+    profiler/index
     tools/autoloader
     tools/finder
     cache/varnish
     testing/index
     event_dispatcher/class_extension
     event_dispatcher/method_behavior
-    profiler/data_collector
     bundles/extension
     request/mime_type
     security/voters

--- a/cookbook/map.rst.inc
+++ b/cookbook/map.rst.inc
@@ -111,6 +111,12 @@
   * :doc:`/cookbook/logging/monolog`
   * :doc:`/cookbook/logging/monolog_email`
 
+* **プロファイラー**
+
+  * :doc:`/cookbook/profiler/data_collector`
+  * :doc:`/cookbook/profiler/matchers`
+  * :doc:`/cookbook/profiler/storage`
+
 * **ツール、内部構造**
 
   * :doc:`/cookbook/tools/autoloader`

--- a/cookbook/profiler/matchers.rst
+++ b/cookbook/profiler/matchers.rst
@@ -167,3 +167,5 @@ Symfony は Path と IPアドレスにマッチすることができる
                 'service' => 'acme_demo.profiler.matcher.super_admin',
             ),
         ));
+
+.. 2014/12/01 kseta 3ba3d278129b9a1a87fa546328888b2be2ff0290

--- a/cookbook/profiler/matchers.rst
+++ b/cookbook/profiler/matchers.rst
@@ -9,10 +9,10 @@
 プロファイラーを条件に応じて有効化する Matchers の使い方
 ========================================================
 
-デフォルトでは Profiler は開発環境でしか有効になっていません。
-しかし、開発者が本番環境でも Profiler を見たいということは想像できます。
-管理者としてログインした場合のみ Profiler を表示させたいという状況もあるでしょう。
-Matchers を使うことで状況に応じて Profiler を有効にすることが可能です。
+デフォルトではプロファイラーは開発環境でしか有効になっていません。
+しかし、開発者が本番環境でもプロファイラーを見たいということは想像できます。
+管理者としてログインした場合のみプロファイラーを表示させたいという状況もあるでしょう。
+Matchers を使うことで状況に応じてプロファイラーを有効にすることが可能です。
 
 built-in Matcher を使う
 --------------------------
@@ -20,7 +20,7 @@ built-in Matcher を使う
 Symfony は Path と IPアドレスにマッチすることができる
 :class:`built-in matcher <Symfony\\Component\\HttpFoundation\\RequestMatcher>`
 を提供しています。
-例えば、もし ``168.0.0.1`` という IP アドレスでアクセスした場合のみ Profiler を表示させたい場合には
+例えば、もし ``168.0.0.1`` という IP アドレスでアクセスした場合のみプロファイラーを表示させたい場合には
 このような設定を使います。
 
 .. configuration-block::
@@ -52,22 +52,22 @@ Symfony は Path と IPアドレスにマッチすることができる
             ),
         ));
 
-Profiler が有効であるべきパスを ``path`` オプションに定義することも可能です。
-例えば、 ``^/admin/`` に設定することで ``/admin/`` という URL のみ Profiler を有効にできます。
+プロファイラーが有効であるべきパスを ``path`` オプションに定義することも可能です。
+例えば、 ``^/admin/`` に設定することで ``/admin/`` という URL のみプロファイラーを有効にできます。
 
 カスタマイズした Matcher を使う
 -------------------------
 
 カスタマイズした Matcher を作ることも可能です。
-これは Profiler を有効にするべきか否かをチェックするサービスです。
+これはプロファイラーを有効にするべきか否かをチェックするサービスです。
 :class:`Symfony\\Component\\HttpFoundation\\RequestMatcherInterface`
 を実装したクラスでサービスを作ります。
 このインターフェースには
 :method:`Symfony\\Component\\HttpFoundation\\RequestMatcherInterface::matches`.
 というメソッドの実装が必要です。
-このメソッドは、 Profiler が無効の場合は False を、有効な場合は True を返します。
+このメソッドは、プロファイラーが無効の場合は False を、有効な場合は True を返します。
 
-``ROLE_SUPER_ADMIN`` がログインした場合に Profiler を有効にするときはこのように実装します::
+``ROLE_SUPER_ADMIN`` がログインした場合にプロファイラーを有効にするときはこのように実装します::
 
     // src/Acme/DemoBundle/Profiler/SuperAdminMatcher.php
     namespace Acme\DemoBundle\Profiler;
@@ -135,7 +135,7 @@ Profiler が有効であるべきパスを ``path`` オプションに定義す�
         );
 
 これでサービスが登録されました。最後の仕上げにこのサービスを Matcher として利用し
-Profiler を設定しましょう:
+プロファイラーを設定しましょう:
 
 .. configuration-block::
 

--- a/cookbook/profiler/storage.rst
+++ b/cookbook/profiler/storage.rst
@@ -6,12 +6,12 @@
 .. index::
     single: Profiling; Storage Configuration
 
-Profiler のストレージを変更する
+プロファイラーのストレージを変更する
 ==============================
 
-デフォルトでは Profiler はキャッシュディレクトリ内のファイルに集積されたデータ蓄積します。
+デフォルトではプロファイラーはキャッシュディレクトリ内のファイルに集積されたデータ蓄積します。
 このストレージは ``dsn``, ``username``, ``password``, ``lifetime`` を介して調整が可能です。
-例えば、lifetime が１時間として MySQL を Profiler のストレージとして仕様する設定は以下の通りです:
+例えば、lifetime が１時間として MySQL をプロファイラーのストレージとして仕様する設定は以下の通りです:
 
 .. configuration-block::
 
@@ -62,7 +62,7 @@ Profiler のストレージを変更する
         ));
 
 :doc:`HttpKernel component </components/http_kernel/introduction>`
-は現在、以下の Profiler 用のストレージをサポートしています。
+は現在、以下のプロファイラー用のストレージをサポートしています。
 
 * :class:`Symfony\\Component\\HttpKernel\\Profiler\\FileProfilerStorage`
 * :class:`Symfony\\Component\\HttpKernel\\Profiler\\MemcachedProfilerStorage`

--- a/cookbook/profiler/storage.rst
+++ b/cookbook/profiler/storage.rst
@@ -71,3 +71,5 @@
 * :class:`Symfony\\Component\\HttpKernel\\Profiler\\MysqlProfilerStorage`
 * :class:`Symfony\\Component\\HttpKernel\\Profiler\\RedisProfilerStorage`
 * :class:`Symfony\\Component\\HttpKernel\\Profiler\\SqliteProfilerStorage`
+
+.. 2014/12/01 kseta 05791bb0cb0a75bb7e36e98a8a0eec79426e02de


### PR DESCRIPTION
## Todo

- [x] Profiler は日本語カタカナで「プロファイラー」に置換
- [x] 翻訳ファイルの末尾に Git コミットハッシュを追記
- [x] cookbook 全体のインデックスの更新

## Refs

https://github.com/symfony-japan/symfony-docs-ja/pull/329