### PR TITLE
Fix error: Integrity constraint violation

### DIFF
--- a/book/doctrine.rst
+++ b/book/doctrine.rst
@@ -887,6 +887,7 @@ Doctrine の metadata のことは、一瞬忘れてみてください。\
             $product = new Product();
             $product->setName('Foo');
             $product->setPrice(19.99);
+            $product->setDescription('Lorem ipsum dolor');
             // この商品をカテゴリに関連付ける
             $product->setCategory($category);
             


### PR DESCRIPTION
```
SQLSTATE[23000]: Integrity constraint violation: 1048 Column 'description' cannot be null
```
というエラーになりました。
本家の英語ドキュメントでは2.0 versionではこの1行が抜けていて、2.3 versionから追加されてました。